### PR TITLE
release 0.1.7-alpha

### DIFF
--- a/.github/workflows/pr_action.yml
+++ b/.github/workflows/pr_action.yml
@@ -25,8 +25,8 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: build
+            - name: Build
               run: |
-                  yarn
-                  yarn build
+                yarn
+                yarn build
               working-directory: ./

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "glitch-deploy-tool",
-    "version": "0.1.6-alpha",
+    "version": "0.1.7-alpha",
     "description": "CLI tool for deploying files to Glitch.com",
     "keywords": [
         "glitch.com",


### PR DESCRIPTION
I accidentally pushed to master... so here is a version bump.

This version adds better null checks when parsing the local git author configuration.
https://github.com/TeamSTEP/glitch-deploy-tool/commit/d13f22d2aa00aae73ef74717a725340f97a73056