### PR TITLE
make M1 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
         "dashdash": "^2.0.0",
         "fs-extra": "^9.0.1",
         "lodash": "^4.17.20",
-        "node": "^15.0.1",
         "node-fetch": "^2.6.1",
         "query-string": "^6.13.6",
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "cli": "NODE_ENV=development ts-node -r dotenv/config scripts/run.ts"
     },
     "engines": {
-        "node": ">=12.x"
+        "node": ">=16.x"
     },
     "funding": {
         "type": "patreon",


### PR DESCRIPTION
requiring "node" as a dependency causes crash in M1 chips: https://github.com/aredridel/node-bin-gen/issues/126